### PR TITLE
refactor(template/project): use new name and slug references for the cli

### DIFF
--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -1,6 +1,4 @@
-# PROJECT-NAME
-
-PROJECT-INFO
+# Project-Name
 
 - [Project Notes](#markdown-header-project-notes)
 - [Getting started](#markdown-header-getting-started)

--- a/templates/project/package-lock.json
+++ b/templates/project/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "project-name",
+	"name": "project-slug",
 	"version": "0.0.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/templates/project/package.json
+++ b/templates/project/package.json
@@ -1,8 +1,12 @@
 {
 	"private": true,
-	"name": "project-name",
+	"name": "project-slug",
 	"version": "0.0.0",
 	"license": "UNLICENSED",
+	"repository": {
+		"type": "git",
+		"url": "git@bitbucket.org:peakfijn/project-slug.git"
+	},
 	"scripts": {
 		"test": "jest",
 		"lint": "tsc && eslint ./src --ext js,jsx,ts,tsx",

--- a/templates/project/sonar-project.properties
+++ b/templates/project/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.host.url=https://sonarcloud.io
+sonar.organization=peakfijn
+sonar.projectKey=peakfijn_project-slug
+sonar.sources=src


### PR DESCRIPTION
### Linked issue
The first draft of the CLI uses both project-name and project-slug variables to set up the project. Lets use these in the templates too.