### PR TITLE
refactor(template/package): use new name and slug references for the cli

### DIFF
--- a/templates/package/README.md
+++ b/templates/package/README.md
@@ -1,17 +1,17 @@
-# modulename - Peakfijn
+# Next Project-Name - Peakfijn
 
-moduledescription
+project-name for Peakfijn Next projects.
 
 <div align="center">
-	<pre>npm install --save @peakfijn/modulename</pre>
+	<pre>npm install --save @peakfijn/next-project-slug</pre>
 </div>
 
 ## Getting started
 
-To set up modulename, we need to initialize ...
+To set up project-name, we need to initialize ...
 
 ```javascript
-import { hello } from '@peakfijn/modulename';
+import { hello } from '@peakfijn/project-slug';
 
 // call hello to use it
 hello();

--- a/templates/package/package.json
+++ b/templates/package/package.json
@@ -1,15 +1,15 @@
 {
 	"private": true,
-	"name": "@peakfijn/modulename",
+	"name": "@peakfijn/next-project-slug",
 	"version": "0.0.0",
-	"description": "moduledescription",
+	"description": "project-name for Peakfijn Next projects",
 	"keywords": [
-		"modulename",
+		"project-slug",
 		"peakfijn"
 	],
 	"author": "Cedric van Putten <cedric@peakfijn.nl>",
 	"license": "MIT",
-	"homepage": "https://github.com/peakfijn/template-next/tree/master/packages/modulename#readme",
+	"homepage": "https://github.com/peakfijn/template-next/tree/master/packages/next-project-slug#readme",
 	"bugs": {
 		"url": "https://github.com/peakfijn/template-next/issues"
 	},


### PR DESCRIPTION
### Linked issue
The first draft of the CLI uses both project-name and project-slug variables to set up the project. Lets use these in the templates too.

### ~~Additional context~~
